### PR TITLE
[BunnyMark] Fix type issue.

### DIFF
--- a/samples/bunnymark/src/Main.hx
+++ b/samples/bunnymark/src/Main.hx
@@ -2,6 +2,8 @@ package;
 
 import openfl.display.FPS;
 import openfl.display.Sprite;
+import openfl.display3D.Context3DProfile;
+import openfl.display3D.Context3DRenderMode;
 import openfl.events.Event;
 import openfl.Lib;
 import starling.core.Starling;
@@ -38,7 +40,7 @@ class Main extends Sprite
 		Starling.handleLostContext = true; // recommended everywhere when using AssetManager
 		RenderTexture.optimizePersistentBuffers = true; // should be safe on Desktop
 		
-		mStarling = new Starling(BunnyMark, stage, null, null, "auto", "baselineExtended");
+		mStarling = new Starling(BunnyMark, stage, null, null, Context3DRenderMode.AUTO, Context3DProfile.BASELINE_EXTENDED);
 		mStarling.antiAliasing = 0;
 		mStarling.simulateMultitouch = false;
 		//mStarling.enableErrorChecking = Capabilities.isDebugger;


### PR DESCRIPTION
Just strings is can cause Haxe compiler issue

``` Haxe
src/Main.hx:43: characters 122-140 : String should be Null<openfl.display3D.Context3DProfile>
src/Main.hx:43: characters 122-140 : String should be openfl.display3D.Context3DProfile
src/Main.hx:43: characters 122-140 : For optional function argument 'profile'
```

 so it is need use these args as OpenFl's enum values.
