### PR TITLE
[TextField] Change font size calculation from cast to round()

### DIFF
--- a/src/starling/text/TextField.hx
+++ b/src/starling/text/TextField.hx
@@ -310,7 +310,7 @@ class TextField extends DisplayObjectContainer
 		if (hAlign == HAlign.LEFT) align = TextFormatAlign.LEFT;
 		else if (hAlign == HAlign.RIGHT) align = TextFormatAlign.RIGHT;
 		else if (hAlign == HAlign.JUSTIFY) align = TextFormatAlign.JUSTIFY;
-		var textFormat:TextFormat = new TextFormat(mFontName, cast(mFontSize * scale, Null<Int>), mColor, mBold, mItalic, mUnderline, null, null, align, null, null, null, null);
+		var textFormat:TextFormat = new TextFormat(mFontName, Math.round(mFontSize * scale), mColor, mBold, mItalic, mUnderline, null, null, align, null, null, null, null);
 		textFormat.kerning = mKerning;
 		if(leading != null)
 			textFormat.leading = mLeading;			


### PR DESCRIPTION
In some cases "scale" might be not equal to 1 and the app crashes with this:

``` Haxe
[Fault] exception, information=Class cast error
```
